### PR TITLE
Rename: 파일 충돌 해결

### DIFF
--- a/src/main/java/JuDBu/custommaster/controller/RootController.java
+++ b/src/main/java/JuDBu/custommaster/controller/RootController.java
@@ -1,4 +1,4 @@
-package JuDBu.custommaster;
+package JuDBu.custommaster.controller;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/JuDBu/custommaster/controller/ord/OrdController.java
+++ b/src/main/java/JuDBu/custommaster/controller/ord/OrdController.java
@@ -1,4 +1,4 @@
-package JuDBu.custommaster.controller;
+package JuDBu.custommaster.controller.ord;
 
 import JuDBu.custommaster.dto.ord.OrdDto;
 import JuDBu.custommaster.service.ord.OrdService;

--- a/src/main/java/JuDBu/custommaster/controller/ord/accept/OrdAcceptRestController.java
+++ b/src/main/java/JuDBu/custommaster/controller/ord/accept/OrdAcceptRestController.java
@@ -1,8 +1,8 @@
-package JuDBu.custommaster.controller.ord.owner;
+package JuDBu.custommaster.controller.ord.accept;
 
 import JuDBu.custommaster.dto.ord.OrdDto;
 import JuDBu.custommaster.entity.ord.Ord;
-import JuDBu.custommaster.service.ord.owner.OrdAcceptService;
+import JuDBu.custommaster.service.ord.accept.OrdAcceptService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/JuDBu/custommaster/controller/ord/accept/OrderAcceptController.java
+++ b/src/main/java/JuDBu/custommaster/controller/ord/accept/OrderAcceptController.java
@@ -1,11 +1,10 @@
-package JuDBu.custommaster.controller.ord.owner;
+package JuDBu.custommaster.controller.ord.accept;
 
 import JuDBu.custommaster.dto.ord.OrdDto;
-import JuDBu.custommaster.service.ord.owner.OrdAcceptService;
+import JuDBu.custommaster.service.ord.accept.OrdAcceptService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
@@ -32,7 +31,7 @@ public class OrderAcceptController {
             Pageable pageable,
             Model model
     ) {
-        Page<OrdDto> ords = ordAcceptService.readAllOrdByShop(shopId, PageRequest.of(0, 10));
+        Page<OrdDto> ords = ordAcceptService.readAllOrdByShop(shopId, pageable);
         List<String> productNames = ordAcceptService.orderProductName(shopId);
         List<String> accountNames = ordAcceptService.getAccountName(shopId);
 

--- a/src/main/java/JuDBu/custommaster/controller/ord/request/FileHandlerUtils.java
+++ b/src/main/java/JuDBu/custommaster/controller/ord/request/FileHandlerUtils.java
@@ -1,4 +1,4 @@
-package JuDBu.custommaster.entity.ord.request;
+package JuDBu.custommaster.controller.ord.request;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/JuDBu/custommaster/controller/ord/request/OrdRequestController.java
+++ b/src/main/java/JuDBu/custommaster/controller/ord/request/OrdRequestController.java
@@ -1,7 +1,7 @@
-package JuDBu.custommaster.entity.ord.request;
+package JuDBu.custommaster.controller.ord.request;
 
-import JuDBu.custommaster.entity.account.Account;
-import JuDBu.custommaster.facade.AuthenticationFacade;
+import JuDBu.custommaster.dto.ord.OrdRequestDto;
+import JuDBu.custommaster.service.ord.request.OrdRequestService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.BindingResult;
@@ -11,9 +11,9 @@ import org.springframework.web.multipart.MultipartFile;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-public class OrdController {
+public class OrdRequestController {
 
-    private final OrdService ordService;
+    private final OrdRequestService ordService;
 
     @GetMapping("/{shopId}/{productId}/request")
     public String requestForm(@ModelAttribute OrdRequestDto requestDto) {

--- a/src/main/java/JuDBu/custommaster/dto/ord/OrdRequestDto.java
+++ b/src/main/java/JuDBu/custommaster/dto/ord/OrdRequestDto.java
@@ -1,4 +1,4 @@
-package JuDBu.custommaster.entity.ord.request;
+package JuDBu.custommaster.dto.ord;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/JuDBu/custommaster/entity/ord/request/OrdRepository.java
+++ b/src/main/java/JuDBu/custommaster/entity/ord/request/OrdRepository.java
@@ -1,8 +1,0 @@
-package JuDBu.custommaster.entity.ord.request;
-
-import JuDBu.custommaster.entity.ord.Ord;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface OrdRepository extends JpaRepository<Ord, Long> {
-
-}

--- a/src/main/java/JuDBu/custommaster/service/ord/accept/OrdAcceptService.java
+++ b/src/main/java/JuDBu/custommaster/service/ord/accept/OrdAcceptService.java
@@ -1,4 +1,4 @@
-package JuDBu.custommaster.service.ord.owner;
+package JuDBu.custommaster.service.ord.accept;
 
 import JuDBu.custommaster.dto.ord.OrdDto;
 import JuDBu.custommaster.entity.account.Account;

--- a/src/main/java/JuDBu/custommaster/service/ord/request/OrdRequestService.java
+++ b/src/main/java/JuDBu/custommaster/service/ord/request/OrdRequestService.java
@@ -1,11 +1,14 @@
-package JuDBu.custommaster.entity.ord.request;
+package JuDBu.custommaster.service.ord.request;
 
 import JuDBu.custommaster.entity.account.Account;
 import JuDBu.custommaster.entity.ord.Ord;
+import JuDBu.custommaster.controller.ord.request.FileHandlerUtils;
+import JuDBu.custommaster.dto.ord.OrdRequestDto;
 import JuDBu.custommaster.entity.product.Product;
 import JuDBu.custommaster.entity.shop.Shop;
 import JuDBu.custommaster.entity.shop.ShopRepository;
 import JuDBu.custommaster.facade.AuthenticationFacade;
+import JuDBu.custommaster.repo.ord.OrdRepo;
 import JuDBu.custommaster.repo.product.ProductRepo;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,9 +20,9 @@ import org.springframework.web.server.ResponseStatusException;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class OrdService {
+public class OrdRequestService {
 
-    private final OrdRepository ordRepository;
+    private final OrdRepo ordRepo;
     private final ShopRepository shopRepository;
     private final ProductRepo productRepository;
     private final AuthenticationFacade authenticationFacade;
@@ -53,7 +56,7 @@ public class OrdService {
         log.info("requestOrder={}", requestOrder);
 
         // 주문 요청 저장
-        Ord savedOrder = ordRepository.save(requestOrder);
+        Ord savedOrder = ordRepo.save(requestOrder);
         log.info("savedOrder={}", savedOrder);
     }
 }

--- a/src/main/resources/templates/ord/ord-detail.html
+++ b/src/main/resources/templates/ord/ord-detail.html
@@ -6,5 +6,6 @@
 </head>
 <body>
     <h2>주문 상세</h2>
+    <hr>
 </body>
 </html>


### PR DESCRIPTION
### 파일명 충돌로 인한 빈 주입 오류 해결
- `OrdController`파일 충돌로 인한 빈 주입 실패
- entity 패키지 내부의 entity 외의 클래스 파일 구조 변경
- 파일 구조 변경 후 기능에 맞는 클래스 이름으로 renaming